### PR TITLE
💄 Adapt sidebar to look better on mobile

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,1 +1,56 @@
 /* Add custom CSS or override theme styles here */
+.sidebar-about h1 {
+    font-size: 2em;
+}
+
+/*
+On small screens (mobile), display a small image next to brand text.
+Also, only show the headings of the menu items and hide the socials (they will be in the footer)
+*/
+@media (max-width: 48em) {
+    .sidebar-about .brand-image {
+        margin-right: 15px;
+    }
+
+    .sidebar-about img {
+        height: 60px;
+        width: 60px;
+    }
+
+    .sidebar-about h1 {
+        font-size: 1.2em;
+    }
+    .sidebar-about p {
+        font-size: 1em;
+    }
+
+    .sidebar-about {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .sidebar-nav {
+        margin: 0;
+    }
+
+    .sidebar-nav li {
+        display: inline-block;
+        margin: 0 10px;
+    }
+
+    .sidebar-nav li.bullet,li.sub-heading {
+        display: none;
+    }
+
+    aside.sidebar a.social, aside.sidebar p.footnote {
+        display: none;
+    }
+}
+
+
+@media (min-width: 48em) {
+    footer {
+        display: none;
+    }
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,20 @@
+{{ partial "head/head.html" . }}
+    <body class="{{if .Site.Params.layoutReverse}}layout-reverse {{end}}{{if .Site.Params.dark_mode}}dark-theme{{end}}">
+        <div class="wrapper">
+            {{ partial "sidebar/sidebar.html" . }}
+            <main class="content container">
+                {{ block "main" . -}}{{- end }}
+            </main>
+            {{ block "sidebar" . }}{{ end }}
+        </div>
+
+        <!--
+            On small displays (mobile) display socials and copyright at the bottom as a fotter.
+            This footer is hidden on larger displays
+        -->
+        <footer class="container sidebar">
+            {{ partial "sidebar/socials.html" . }}
+            {{ partial "sidebar/copyright.html" . }}
+        </footer>
+    </body>
+</html>

--- a/layouts/partials/sidebar/title.html
+++ b/layouts/partials/sidebar/title.html
@@ -1,0 +1,25 @@
+<div class="sidebar-about">
+    <div class="brand-image">
+        {{ if .Site.Params.remote_brand_image }}
+        <a href="{{ .Site.BaseURL }}">
+            <img src="{{ .Site.Params.remote_brand_image }}" alt="brand image">
+        </a>
+        {{ else if .Site.Params.brand_image }}
+        <a href="{{ .Site.BaseURL }}">
+            <img src="{{ .Site.Params.brand_image }}" alt="brand image">
+        </a>
+        {{ end }}
+    </div>
+
+
+    <div class="brand-text">
+        {{ if .Site.Params.brand }}
+        <a href="{{ .Site.BaseURL }}">
+            <h1>{{ .Site.Params.brand }}</h1>
+        </a>
+        {{ end }}
+        <p class="lead">
+            {{ with .Site.Params.description }}{{. | safeHTML}}{{end}}
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
Before this change, the full sidebar was rendered on the top of the page when viewing it on mobile devices. I could not even see the headline of the post I was reading because my screen was filled with the sidebar.

This change shrinks the contents of the sidebar such that the profile picture and the name is rendered next to each other. Additionally, only the post categories are shown next to each other (e.g. About, Posts). Finally, the footer (incl. socials etc) is displayed at the bottom of the page.



| Mobile view before | and after this change |
| -- | -- |
| ![Bildschirmfoto am 2025-03-23 um 17 46 10](https://github.com/user-attachments/assets/f39ad183-e730-43f1-87e2-59c7778335f1) | ![Bildschirmfoto am 2025-03-23 um 17 48 18](https://github.com/user-attachments/assets/5151036e-51c9-4871-9d7d-02d41978da3e) |